### PR TITLE
Easier-to-use editor links

### DIFF
--- a/Kint.class.php
+++ b/Kint.class.php
@@ -321,8 +321,9 @@ class Kint
 		}
 
 		$url = str_replace( array( '%f', '%l' ), array( $file, $line), self::$fileLinkFormat );
+		$class = ( strpos( $url, 'http://' ) === 0 ) ? 'class="kint-ide-link"' : '';
 
-		return "<u><a href=\"{$url}\">{$shortenedName}</a></u> line <i>{$line}</i>";
+		return "<u><a {$class} href=\"{$url}\">{$shortenedName}</a></u> line <i>{$line}</i>";
 	}
 
 

--- a/Kint.class.php
+++ b/Kint.class.php
@@ -19,6 +19,7 @@ class Kint
 	// these are all public and 1:1 config array keys so you can switch them easily
 	public static $traceCleanupCallback;
 	public static $pathDisplayCallback;
+	public static $fileLinkFormat;
 	public static $hideSequentialKeys;
 	public static $showClassConstants;
 	public static $keyFilterCallback;
@@ -81,6 +82,7 @@ class Kint
 
 
 		self::$pathDisplayCallback or self::$pathDisplayCallback = "kint::_debugPath";
+		self::$fileLinkFormat or self::$fileLinkFormat = ini_get('xdebug.file_link_format');
 	}
 
 	/**
@@ -306,18 +308,21 @@ class Kint
 	 */
 	protected static function _debugPath( $file, $line = NULL )
 	{
-		if ( !$line ) { // called from resource dump
-			return $file;
+		$shortenedName = strpos( $file, $_SERVER['DOCUMENT_ROOT'] ) === 0
+			? htmlspecialchars('<docroot>') . substr( $file, strlen( $_SERVER['DOCUMENT_ROOT'] ) )
+			: $file;
+
+		if ( !$line ) { // means this is called from resource type dump
+			return $shortenedName;
 		}
 
-		$path = str_replace( '/', '\\', $file );
-		$root = str_replace( '/', '\\', $_SERVER['DOCUMENT_ROOT'] );
-
-		if ( strpos( $path, $root ) === 0 ) {
-			$path = 'ROOT' . substr( $path, strlen( $root ) );
+		if ( !self::$fileLinkFormat ) {
+			return "{$shortenedName} line <i>{$line}</i>";
 		}
 
-		return "<u>" . $path . "</u> line <i>{$line}</i>";
+		$url = str_replace( array( '%f', '%l' ), array( $file, $line), self::$fileLinkFormat );
+
+		return "<u><a href=\"{$url}\">{$shortenedName}</a></u> line <i>{$line}</i>";
 	}
 
 

--- a/config.default.php
+++ b/config.default.php
@@ -46,24 +46,20 @@ $_kintSettings['displayCalledFrom'] = true;
  *
  * @return string html - escaped string
  *
- * [!] EXAMPLE (works with for phpStorm and RemoteCall Plugin):
- *
- * $_kintSettings['pathDisplayCallback'] = function( $file, $line = NULL ) {
- *     $shortenedName = strpos( $file, $_SERVER['DOCUMENT_ROOT'] ) === 0
- *         ? 'DOCUMENT_ROOT' . DIRECTORY_SEPARATOR . substr( $file, strlen( $_SERVER['DOCUMENT_ROOT'] ) )
- *         : $file;
- *
- *     if ( !$line ) { // means this is called from resource type dump
- *         return $shortenedName;
- *     }
- *
- *     return "<u><a class=\"kint-ide-link\" href=\"http://localhost:8091/?message={$file}:{$line}\">"
- *         . $shortenedName
- *         . "</a></u> line <i>{$line}</i>";
- * };
+ * This is only provided for backwards compatibility; you probably want to use fileLinkFormat instead.
  */
 $_kintSettings['pathDisplayCallback'] = null;
 
+/**
+ * @var string format of the link to the source file in trace entries. Use %f for file path, %l for line number.
+ * Defaults to xdebug.file_link_format if not set.
+ *
+ * [!] EXAMPLE (works with for phpStorm and RemoteCall Plugin):
+ *
+ * $_kintSettings['fileLinkFormat'] = 'http://localhost:8091/?message=%f:%l';
+ *
+ */
+$_kintSettings['fileLinkFormat'] = null;
 
 /**
  * @var callback|null

--- a/scripts/source.reg
+++ b/scripts/source.reg
@@ -1,0 +1,12 @@
+REGEDIT4
+
+[HKEY_CLASSES_ROOT\source]
+@="URL:source Protocol"
+"URL Protocol"=""
+
+[HKEY_CLASSES_ROOT\source\shell]
+
+[HKEY_CLASSES_ROOT\source\shell\open]
+
+[HKEY_CLASSES_ROOT\source\shell\open\command]
+@="wscript.exe \"C:\\Program Files\\bin\\source.vbs\" \"%1\"" 

--- a/scripts/source.vbs
+++ b/scripts/source.vbs
@@ -1,0 +1,80 @@
+'INSTALLATION:
+'set editor link format to 'source:<filename>:<line>'
+'move this file to C:\Program Files\bin\source.vbs and run source.reg
+'customize directory mappings and editor command below
+
+'*****************
+'start of settings
+'*****************
+Dim command, protocol, change_slashes, debug
+Set dirmap = CreateObject("Scripting.Dictionary")
+
+'list of server paths (as regular expressions) 
+'and matching local paths (as regexp replace strings)
+'use this to replace the beginning of the path
+'if none of the regular expressions match, the script will show an error
+
+'local setup, when PHP and editor runs from the same machine
+dirmap.Add "^([C-Z]:\\)", "$1"
+
+'a typical remote Linux setup
+'dirmap.Add "^/var/www/", "C:\Projects\"
+'dirmap.Add "^/usr/share/php5/",  "C:\Projects\debug-source"
+
+'command to execute; %f is the file name, %l is the line number
+'dont forget to quote file names (quotes can be escaped by writing twice)
+command = """C:\Program Files\Notepad++\notepad++.exe"" -n%l ""%f"""
+
+'if true, forward slashes will be changed to backslashes in the filename
+'(after the regex replacements)
+change_slashes = True
+
+'protocol name used in the source edit links
+protocol = "source"
+
+'if true, alerts the command before executing it
+debug = False
+
+'***************
+'end of settings
+'***************
+
+Select Case WScript.Arguments.Count
+	Case 0
+		WScript.Echo "Wrong source link"
+		WScript.Quit
+End Select
+
+Dim link, split, file, line, found, strArgs
+
+link = Mid(WScript.Arguments.Item(0), Len(protocol) + 2)
+split = InStrRev(link, ":")
+file = Left(link, split - 1)
+line = Mid(link, split + 1)
+
+found = False
+For Each serverPath In dirmap
+	Set regexp = New RegExp
+	regexp.Pattern = serverPath
+	If regexp.Test(file) Then
+		found = True
+		Exit For
+	End If
+Next
+If Not found Then
+	WScript.Echo "don't know where to find " & file & " locally"
+	WScript.Quit
+End If
+file = regexp.Replace(file, dirmap.Item(serverPath))
+if change_slashes Then
+	file = Replace(file, "/", "\")
+End If
+
+strArgs = command
+strArgs = Replace(strArgs, "%l", line)
+strArgs = Replace(strArgs, "%f", file)
+If debug Then
+	WScript.Echo strArgs
+End If
+Set oShell = CreateObject ("Wscript.Shell") 
+oShell.Run strArgs, 0, false


### PR DESCRIPTION
- adds ability to define the format of the editor links as a simple string, without the need to override pathDisplayCallback (and have to deal with stuff like resource files in trace)
- takes default from xdebug.file_link_format if available
- adds example scripts to register custom protocol and open any editor from command line in Windows

Fixes issues [28](http://code.google.com/p/kint/issues/detail?id=28) and [34](http://code.google.com/p/kint/issues/detail?id=34) on the old tracker.
