### PR TITLE
BUG: splObjectStorage produced exception

### DIFF
--- a/parsers/custom/splobjectstorage.php
+++ b/parsers/custom/splobjectstorage.php
@@ -9,8 +9,8 @@ class Kint_Parsers_SplObjectStorage extends kintParser
 
 		$variable->rewind();
 		while ( $variable->valid() ) {
-			$tmp            = kintParser::factory( $variable->current() );
-			$this->_value[] = $tmp;
+                        $current = $variable->current();
+			$this->_value[] = kintParser::factory( $current );
 			$variable->next();
 		}
 


### PR DESCRIPTION
splObjectStorage produced an exception. The problem is that the parser Factory method expects to receive a reference to a variable. We were calling it with the result of a function call and this cannot be used in a call by reference. Added a variable to call the function. Also removed an unused tmp variable
