### PR TITLE
Implements bypass callback to create your own dump wrapper function.

### DIFF
--- a/Kint.class.php
+++ b/Kint.class.php
@@ -27,6 +27,7 @@ class Kint
 	public static $enabled;
 	public static $theme;
 	public static $devel;
+	public static $bypasscallbacks;
 
 
 	protected static $_firstRun = true;
@@ -388,15 +389,29 @@ class Kint
 	{
 		$previousCaller = array();
 		while ( $callee = array_pop( $trace ) ) {
-			if ( strtolower( $callee['function'] ) === 'd' ||
-				strtolower( $callee['function'] ) === 'dd' ||
-				( isset( $callee['class'] ) && strtolower( $callee['class'] ) === strtolower( __CLASS__ )
-					&& strtolower( $callee['function'] ) === 'dump' )
-			) {
-				break;
-			} else {
-				$previousCaller = $callee;
+			foreach( Kint::$bypasscallbacks as $callback ) {
+				if ( isset( $callee['class'] ) && is_array( $callback ) ) {
+					if ( is_string( $callback[0] ) && $callback[0] == '__CLASS__'
+						&& strtolower( $callee['class'] ) === strtolower( __CLASS__ )
+						&& strtolower( $callee['function'] ) === $callback[1]
+					) {
+						break 2;
+					} elseif ( is_string( $callback[0] )
+						&& strtolower( $callee['class'] ) === strtolower( $callback[0] )
+						&& strtolower( $callee['function'] ) === $callback[1]
+					) {
+						break 2;
+					} elseif ( is_object( $callback[0] )
+						&& strtolower( $callee['class'] ) === strtolower( get_class( $callback[0] ) )
+						&& strtolower( $callee['function'] ) === $callback[1]
+					) {
+						break 2;
+					}
+				} elseif (strtolower( $callee['function'] ) == $callback) {
+					break 2;
+				}
 			}
+			$previousCaller = $callee;
 		}
 
 		if ( !isset( $callee['file'] ) || !is_readable( $callee['file'] ) ) {
@@ -417,7 +432,7 @@ class Kint
 
 		$codePattern = empty( $callee['class'] )
 			? $callee['function']
-			: $callee['class'] . "\x07*" . $callee['type'] . "\x07*" . $callee['function'];
+			: ( $callee['type'] == '::' ? $callee['class'] : '\\$[a-zA-Z1-9_]*' ) . "\x07*" . $callee['type'] . "\x07*" . $callee['function'];
 		# get the position of the last call to the function
 		preg_match_all( "#[\x07{(](\\+|-|!|@)?{$codePattern}\x07*(\\()#i", $source, $matches, PREG_OFFSET_CAPTURE );
 		$match    = end( $matches[2] );

--- a/config.default.php
+++ b/config.default.php
@@ -123,5 +123,7 @@ $_kintSettings['keyFilterCallback'] = null;
 /** @var bool only set to true if you want to develop kint and know what you're doing */
 $_kintSettings['devel'] = false;
 
+/** @var array list of callback to bypass during the dump */
+$_kintSettings['bypasscallbacks'] = array(array('__CLASS__', 'dump'), 'd', 'dd', array('K', 'd'), array('K', 's'));
 
 unset( $_kintSettings );


### PR DESCRIPTION
Now you can add a wrapper to the Kint::dump();
Your wrapper function have to be added to the new bypasscallbacks setting.
