### PR TITLE
Added classmethods parser

### DIFF
--- a/parsers/custom/classmethods.php
+++ b/parsers/custom/classmethods.php
@@ -2,18 +2,18 @@
 
 class Kint_Parsers_ClassMethods extends kintParser
 {
-	protected function _parse(&$variable)
-	{
-		if(!is_object($variable)) {
+    protected function _parse(&$variable)
+    {
+        if(!is_object($variable)) {
             return false;
         }
 
-		$reflection = new \ReflectionClass($variable);
+        $reflection = new \ReflectionClass($variable);
 
         $public = $private = $protected = array();
 
         // Class methods
-		foreach($reflection->getMethods() as $method) {
+        foreach($reflection->getMethods() as $method) {
             $params = array();
 
             // Access type
@@ -67,7 +67,7 @@ class Kint_Parsers_ClassMethods extends kintParser
 
             $output = new \kintVariableData();
             $output->name = $methodName . '(' . implode(', ', $params) . ')';
-			$output->access = $access;
+            $output->access = $access;
 
             if(is_string($docBlock)) {
                 $lines = array();
@@ -98,7 +98,7 @@ class Kint_Parsers_ClassMethods extends kintParser
             } else {
                 $public[$access . $methodName] = $output;
             }
-		}
+        }
 
         if(!$private && !$protected && !$public) {
             return false;
@@ -110,8 +110,8 @@ class Kint_Parsers_ClassMethods extends kintParser
 
         $extendedValue = $public + $protected + $private;
 
-		$this->value = $extendedValue;
-		$this->type = 'methods';
-		$this->size = count($extendedValue);
-	}
+        $this->value = $extendedValue;
+        $this->type = 'methods';
+        $this->size = count($extendedValue);
+    }
 }

--- a/parsers/custom/classmethods.php
+++ b/parsers/custom/classmethods.php
@@ -1,0 +1,117 @@
+<?php
+
+class Kint_Parsers_ClassMethods extends kintParser
+{
+	protected function _parse(&$variable)
+	{
+		if(!is_object($variable)) {
+            return false;
+        }
+
+		$reflection = new \ReflectionClass($variable);
+
+        $public = $private = $protected = array();
+
+        // Class methods
+		foreach($reflection->getMethods() as $method) {
+            $params = array();
+
+            // Access type
+            $access = implode(' ', \Reflection::getModifierNames($method->getModifiers()));
+
+            // Method parameters
+            foreach($method->getParameters() as $param) {
+                $paramString = '';
+
+                if($param->isArray()) {
+                    $paramString .= 'array ';
+                } elseif($param->getClass()) {
+                    $paramString .= $param->getClass()->name . ' ';
+                }
+
+                $paramString .= ($param->isPassedByReference() ? '&' : '') . '$' . $param->getName();
+
+                if($param->isDefaultValueAvailable()) {
+                    if($param->getDefaultValue() === null){
+                        $defaultValue = 'NULL';
+                    } elseif($param->getDefaultValue() === false){
+                        $defaultValue = 'false';
+                    } elseif($param->getDefaultValue() === true){
+                        $defaultValue = 'true';
+                    } elseif($param->getDefaultValue() === ''){
+                        $defaultValue = '""';
+                    } else {
+                        $defaultValue = $param->getDefaultValue();
+                    }
+
+                    $paramString .= ' = ' . $defaultValue;
+                }
+
+                $params[] = $paramString;
+            }
+
+            $return = false;
+
+            // Simple DocBlock parser, look for @return
+            if(($docBlock = $method->getDocComment())) {
+                $matches = array();
+                if(preg_match_all('/@(\w+)\s+(.*)\r?\n/m', $docBlock, $matches)) {
+                    $lines = array_combine($matches[1], $matches[2]);
+                    if(isset($lines['return'])) {
+                        $return = $lines['return'];
+                    }
+                }
+            }
+
+            $methodName = ($method->returnsReference() ? '&' : '') . $method->getName();
+
+            $output = new \kintVariableData();
+            $output->name = $methodName . '(' . implode(', ', $params) . ')';
+			$output->access = $access;
+
+            if(is_string($docBlock)) {
+                $lines = array();
+                foreach(explode("\n", $docBlock) as $line) {
+                    $line = trim($line);
+
+                    if(in_array($line, array('/**', '/*', '*/'))) {
+                        continue;
+                    }elseif(strpos($line, '*') === 0) {
+                        $line = substr($line, 1);
+                    }
+
+                    $lines[] = trim($line);
+                }
+
+                $output->extendedValue = implode("\n", $lines);
+            }
+
+            if($return) {
+                $output->operator = '->';
+                $output->type = $return;
+            }
+
+            if($method->isPrivate()) {
+                $private[$access . $methodName] = $output;
+            } elseif($method->isProtected()) {
+                $protected[$access . $methodName] = $output;
+            } else {
+                $public[$access . $methodName] = $output;
+            }
+		}
+
+        if(!$private && !$protected && !$public) {
+            return false;
+        }
+
+        ksort($public);
+        ksort($protected);
+        ksort($private);
+
+        $extendedValue = $public + $protected + $private;
+
+		$this->value = $extendedValue;
+		$this->type = 'methods';
+		$this->size = count($extendedValue);
+	}
+}

--- a/parsers/custom/classmethods.php
+++ b/parsers/custom/classmethods.php
@@ -32,7 +32,14 @@ class Kint_Parsers_ClassMethods extends kintParser
                 $paramString .= ($param->isPassedByReference() ? '&' : '') . '$' . $param->getName();
 
                 if($param->isDefaultValueAvailable()) {
-                    if($param->getDefaultValue() === null){
+                    if(is_array($param->getDefaultValue())) {
+                        $arrayValues = array();
+                        foreach($param->getDefaultValue() as $key => $value) {
+                            $arrayValues[] = $key . ' => ' . $value;
+                        }
+
+                        $defaultValue = 'array(' . implode(', ', $arrayValues) . ')';
+                    } elseif($param->getDefaultValue() === null){
                         $defaultValue = 'NULL';
                     } elseif($param->getDefaultValue() === false){
                         $defaultValue = 'false';
@@ -63,10 +70,8 @@ class Kint_Parsers_ClassMethods extends kintParser
                 }
             }
 
-            $methodName = ($method->returnsReference() ? '&' : '') . $method->getName();
-
             $output = new \kintVariableData();
-            $output->name = $methodName . '(' . implode(', ', $params) . ')';
+            $output->name = ($method->returnsReference() ? '&' : '') . $method->getName() . '(' . implode(', ', $params) . ')';
             $output->access = $access;
 
             if(is_string($docBlock)) {
@@ -91,12 +96,14 @@ class Kint_Parsers_ClassMethods extends kintParser
                 $output->type = $return;
             }
 
+            $sortName = $access . $method->getName();
+
             if($method->isPrivate()) {
-                $private[$access . $methodName] = $output;
+                $private[$sortName] = $output;
             } elseif($method->isProtected()) {
-                $protected[$access . $methodName] = $output;
+                $protected[$sortName] = $output;
             } else {
-                $public[$access . $methodName] = $output;
+                $public[$sortName] = $output;
             }
         }
 


### PR DESCRIPTION
I have added class methods parser, shows as additional tab for objects.

Example: http://www.opengluco.com/demo/kint/demo.php

It shows all class methods sorted by access type and name.

The "+" displays documentation block (if available for given method).

Return value is parsed from PHPDocumentor @return if available.

![kint_classmethods](https://f.cloud.github.com/assets/4125756/368153/6857da66-a2b9-11e2-94b6-1588950a47f4.png)
