### PR TITLE
FIX: Crash on @thobbs/phpcassa objects with UUIDs

### DIFF
--- a/parsers/parser.class.php
+++ b/parsers/parser.class.php
@@ -508,7 +508,7 @@ class kintVariableData
 		}
 
 		if ( empty( Kint::$charEncodings ) || !function_exists( 'iconv' ) ) {
-			return isset( $mbDetected ) ? $mbDetected : 'UTF-8';
+			return !empty( $mbDetected ) ? $mbDetected : 'UTF-8';
 		}
 
 		$md5 = md5( $value );


### PR DESCRIPTION
Error was:

```
PHP warning
mb_strlen(): Unknown encoding ""
raveren/kint/parsers/parser.class.php(559)
```
