### PR TITLE
added support for displaying objects' __toString() methods

### DIFF
--- a/Kint.class.php
+++ b/Kint.class.php
@@ -18,6 +18,7 @@ class Kint
 	public static $traceCleanupCallback;
 	public static $fileLinkFormat;
 	public static $hideSequentialKeys;
+	public static $displayToString;
 	public static $showClassConstants;
 	public static $keyFilterCallback;
 	public static $displayCalledFrom;

--- a/config.default.php
+++ b/config.default.php
@@ -93,6 +93,10 @@ $_kintSettings['maxLevels'] = 5;
 $_kintSettings['hideSequentialKeys'] = true;
 
 
+/** @var bool whether to display the objects' __toString() methods or not */
+$_kintSettings['displayToString'] = true;
+
+
 /** @var string name of theme for rich view */
 $_kintSettings['theme'] = 'original';
 

--- a/parsers/custom/objecttostring.php
+++ b/parsers/custom/objecttostring.php
@@ -1,0 +1,15 @@
+<?php
+class Kint_Parsers_ObjectToString extends kintParser
+{
+    
+	protected function _parse( & $variable )
+	{
+		if ( !is_object( $variable ) || ! Kint::$displayToString || ! method_exists($variable, '__toString') ) 
+		    return false;
+
+		$string = $variable->__toString();
+	    $this->value = self::_escape($string);
+	    $this->type = '__toString';
+	    $this->size = self::_strlen($string);
+	}
+}

--- a/parsers/parser.class.php
+++ b/parsers/parser.class.php
@@ -322,6 +322,21 @@ abstract class kintParser extends kintVariableData
 			$variableData->extendedValue = "*DEPTH TOO GREAT*";
 			return false;
 		}
+		
+		// use __toString if it exists to display some debugging info in the object header
+		if (Kint::$displayToString && method_exists($variable, '__toString'))
+		{
+		    $string = $variable->__toString();
+		    
+		    $size           = self::_strlen( $string );
+		    $strippedString = self::_stripWhitespace( $string );
+		    if ( Kint::$maxStrLength && $size > Kint::$maxStrLength ) {
+		        // encode and truncate
+		        $variableData->value .= '&quot;' . str_replace(array("\r\n","\r","\n"), "", (self::_substr( $strippedString, Kint::$maxStrLength))) . '&nbsp;&hellip;&quot;';
+		    } else {
+		        $variableData->value .= '&quot;' . self::_escape( $string ) . '&quot;';
+		    }
+		}
 
 		self::$_objects[$hash] = true;
 

--- a/tests/testToString.php
+++ b/tests/testToString.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * test object->__toString()
+ * 
+ * (Just a proof of concept test, because I can't use a test suite here)
+ */
+
+require_once '../Kint.class.php';
+
+class Car
+{
+    protected $brand;
+    
+    function __construct($brand)
+    {
+        $this->brand = $brand;
+    }
+    
+    public function __toString()
+    {
+        return $this->brand;
+    }
+}
+
+$volvo = new Car('Volvo');
+
+d($volvo);
+
+// it's benefit is mainly here: identify the objects when they are collapsed
+// (open the array not by clicking the [+], but by clicking the array header row) 
+$array = array(new Car('Volvo'),
+               new Car('Porsche'),
+               new Car('Toyota'),
+               );
+
+d($array);
+


### PR DESCRIPTION
by adding
- config displayToString (default set to true for this fork)
- string display in object header row in parser.class.php
- custom parser to display full toString as a seperate tab
- test for displaying
