### PR TITLE
Last callee fix in _getPassedNames()

### DIFF
--- a/Kint.class.php
+++ b/Kint.class.php
@@ -392,6 +392,7 @@ class Kint
 				( isset( $callee['class'] ) && strtolower( $callee['class'] ) === strtolower( __CLASS__ )
 					&& strtolower( $callee['function'] ) === 'dump' )
 			) {
+				$callee = $previousCaller;
 				break;
 			} else {
 				$previousCaller = $callee;


### PR DESCRIPTION
If we going thru whole backtrace we need to set previous passed element as callee instead just breaking cycle and save current callee as needed callee. 

It fixed problem in my Drupal module:
"Called From" string contains last called function place (kint() - custom alias) instead current place when i execute my kint() function.

Example of alias, calling of one will prints kint::dump() without information about called from place:
https://gist.github.com/fat763/7306086

Please, comment this situation.

Thank you!
