### PR TITLE
Default configuration rework. Function's aliases move to config.

### DIFF
--- a/Kint.class.php
+++ b/Kint.class.php
@@ -64,18 +64,7 @@ class Kint
 	/** @var  string cli|plain|whitespace|rich */
 	public static $mode = 'rich';
 
-	public static $aliases = array(
-		'methods'   => array(
-			array( 'kint', 'dump' ),
-			array( 'kint', 'trace' ),
-		),
-		'functions' => array(
-			'd',
-			'dd',
-			's',
-			'sd',
-		)
-	);
+	public static $aliases;
 
 	protected static $_firstRun = true;
 

--- a/config.default.php
+++ b/config.default.php
@@ -1,7 +1,4 @@
 <?php
-isset( $GLOBALS['_kint_settings'] ) or $GLOBALS['_kint_settings'] = array();
-$_kintSettings = &$GLOBALS['_kint_settings'];
-
 
 /** @var bool if set to false, kint will become silent, same as Kint::enabled(false) or Kint::$enabled = false */
 $_kintSettings['enabled'] = true;
@@ -121,5 +118,28 @@ $_kintSettings['theme'] = 'original';
  *
  */
 $_kintSettings['keyFilterCallback'] = null;
+
+/** Define aliases of functions that will be excluded from Backtrace and Called from */
+$_kintSettings['aliases'] = array(
+  'methods'   => array(
+    array('kint', 'dump'),
+    array('kint', 'trace'),
+  ),
+  'functions' => array(
+    'd',
+    'dd',
+    's',
+    'sd',
+    'kint',
+    'kint_trace',
+  )
+);
+
+/** Set config parameters to default values if they are not exists */
+foreach ($_kintSettings as $key => $value) {
+  if (!isset($GLOBALS['_kint_settings'][$key])) {
+    $GLOBALS['_kint_settings'][$key] = $value;
+  }
+}
 
 unset( $_kintSettings );


### PR DESCRIPTION
Hey, Rokas! Once more, thanks for awesome tool!

I developing Kint port for Drupal and i found that there is no possibility to preconfigure Kint default settings from outside of Kint distribution.

For now Kint requires: config.default.php + config.php
How about to create something like this? :
1) Framework's/CMS settings (stored in $GLOBAL['_kintSettings'])
2) config.default.php - on this step fill only parameters that not setted
3) config.php (if it exists) - has higher priority and overrides any configuration property

If i just download Kint distribution and use it in any framework\cms - it should pe possible to use original Kint distribution instead adapted forks and configure should be as flexible as possible, i think.

Also, i think any framework\cms can provide self alias for Kint::dump(), maybe it is more useful to move aliases configuration to config? (that can be preconfigured before Kint is included).

In this pull request i moved aliases definition into config file and in default.config.php at end of file set only not setted config properties.

If you will accept this pull request - i can finish my Drupal module and set one as stable.

Waiting for your response. 
Thanks!
