### PR TITLE
Allow users to specify which IPs are allow to debug

### DIFF
--- a/Kint.class.php
+++ b/Kint.class.php
@@ -34,7 +34,6 @@ class Kint
 
 	# non-standard function calls
 	protected static $_statements = array( 'include', 'include_once', 'require', 'require_once' );
-
 	/**
 	 * getter/setter for the enabled parameter, called at the beginning of every public function as getter, also
 	 * initializes the settings if te first time it's run.
@@ -45,13 +44,15 @@ class Kint
 	 */
 	public static function enabled( $value = null )
 	{
-		# act both as a setter...
-		if ( func_num_args() > 0 ) {
-			self::$enabled = $value;
-			return;
-		}
-
-		# ...and a getter
+        echo "My IP:".$_SERVER['REMOTE_ADDR']."<br>\n";
+        echo "Allowed:".implode('&nbsp; ',Configuration::getAllowed())."<br>\n";
+        if (in_array($_SERVER['REMOTE_ADDR'],Configuration::getAllowed())) {
+            if ( func_num_args() > 0 ) {
+                self::$enabled = $value;
+            }
+        } else {
+            self::$enabled = false;
+        }
 		return self::$enabled;
 	}
 

--- a/Kint.class.php
+++ b/Kint.class.php
@@ -30,6 +30,8 @@ class Kint
 	public static $expandedByDefault;
 	public static $devel; # todo remove
 
+    private static $allowedDebuggers;
+
 	protected static $_firstRun = true;
 
 	# non-standard function calls
@@ -44,9 +46,7 @@ class Kint
 	 */
 	public static function enabled( $value = null )
 	{
-        echo "My IP:".$_SERVER['REMOTE_ADDR']."<br>\n";
-        echo "Allowed:".implode('&nbsp; ',Configuration::getAllowed())."<br>\n";
-        if (in_array($_SERVER['REMOTE_ADDR'],Configuration::getAllowed())) {
+        if (in_array($_SERVER['REMOTE_ADDR'],self::$allowedDebuggers)) {
             if ( func_num_args() > 0 ) {
                 self::$enabled = $value;
             }

--- a/config.default.php
+++ b/config.default.php
@@ -6,6 +6,8 @@ $_kintSettings = &$GLOBALS['_kint_settings'];
 /** @var bool if set to false, kint will become silent, same as Kint::enabled(false) or Kint::$enabled = false */
 $_kintSettings['enabled'] = true;
 
+/** @var array list of ip addresses allowed to debug, any ip address not listed will not be able to debug */
+$_kintSettings['allowedDebuggers'] = array('127.0.0.1');
 
 /**
  * @var bool whether to display where kint was called from


### PR DESCRIPTION
A simple check to see if the requested IP address is in the array.  This allows us to point the config variable into a database or load it via a static list of develop ip addresses.  In our code we use a local Kint::enable to allow debugging or not.  Works in development and UAT.
