### PR TITLE
Switch from Composer Files autoload to classmap

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "php": ">=5.2.0"
     },
     "autoload": {
-        "files": ["Kint.class.php"]
+        "classmap": ["Kint.class.php"]
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
Using the "Files" classloader always includes the file in every request. We should use the more appropriate Classmap loader.
