### PR TITLE
Remove self::_char( "═", 80 ) and Title if $returnOutput = true

### DIFF
--- a/decorators/plain.php
+++ b/decorators/plain.php
@@ -223,6 +223,7 @@ class Kint_Decorators_Plain
 
 	private static function _title( $text )
 	{
+		if ( Kint::$returnOutput ) return '';
 		$escaped          = kintParser::escape( $text );
 		$lengthDifference = strlen( $escaped ) - strlen( $text );
 		return
@@ -251,7 +252,7 @@ class Kint_Decorators_Plain
 
 	public static function wrapEnd( $callee, $miniTrace, $prevCaller )
 	{
-		$lastLine = self::_colorize( self::_char( "═", 80 ), 'title' );
+		$lastLine = Kint::$returnOutput === false ? self::_colorize( self::_char( "═", 80 ), 'title' ) : '';
 		$lastChar = Kint::enabled() === Kint::MODE_PLAIN ? '</pre>' : '';
 
 


### PR DESCRIPTION
\Kint::$displayCalledFrom = false;
\Kint::enabled( \Kint::MODE_WHITESPACE );
\Kint::$returnOutput = true;
$output = \Kint::dump( $data );

but I still have the ======== x80 in the end and [ $varName] in the begin.
