### PR TITLE
Check for method_exists getClosureThis

### DIFF
--- a/parsers/objects/closure.php
+++ b/parsers/objects/closure.php
@@ -21,7 +21,7 @@ class Kint_Objects_Closure extends KintObject
 		if ( $val = $reflection->getStaticVariables() ) {
 			$ret['Uses'] = $val;
 		}
-		if ( $val = $reflection->getClosureThis() ) {
+		if ( method_exists($reflection, 'getClousureThis') && $val = $reflection->getClosureThis() ) {
 			$ret['Uses']['$this'] = $val;
 		}
 		if ( $val = $reflection->getFileName() ) {


### PR DESCRIPTION
Looks like that function was added in 5.4: http://php.net/manual/en/reflectionfunctionabstract.getclosurethis.php

My PHP 5.3 environment (we'll upgrade soon, but we haven't gotten to it yet) chokes on this call.  This check fixes the problem for me.  Packagist says you support back to 5.1.  If you only claimed support for 5.4 and up, I wouldn't request the change.  Thanks for the excellent library!
