### PR TITLE
Move _firstRun into decorators to ensure styles are output

### DIFF
--- a/decorators/plain.php
+++ b/decorators/plain.php
@@ -2,6 +2,7 @@
 
 class Kint_Decorators_Plain
 {
+	public static $firstRun = true;
 	private static $_enableColors;
 
 	private static $_cliEffects      = array(

--- a/decorators/rich.php
+++ b/decorators/rich.php
@@ -2,6 +2,7 @@
 
 class Kint_Decorators_Rich
 {
+	public static $firstRun = true;
 	# make calls to Kint::dump() from different places in source coloured differently.
 	private static $_usedColors = array();
 


### PR DESCRIPTION
Keeps styles outputting once per decorator, but ensures they are output at least once each.

Before, if you called `s()` first the styles and javascript for `d()` wouldn't load, now they both load once.
