### PR TITLE
Suggested feature to exclude certain classes from being parsed and dumped

### DIFF
--- a/Kint.class.php
+++ b/Kint.class.php
@@ -48,6 +48,7 @@ class Kint
 	public static $maxLevels;
 	public static $theme;
 	public static $expandedByDefault;
+	public static $excludeClassInstances;
 
 	public static $cliDetection;
 	public static $cliColors;

--- a/config.default.php
+++ b/config.default.php
@@ -90,5 +90,7 @@ $_kintSettings['cliDetection'] = true;
  */
 $_kintSettings['cliColors'] = true;
 
+/** @var array - allows to exclude certain classes from being parsed, must be a list of fully qualified domain names */
+$_kintSettings['excludeClassInstances'] = [];
 
 unset( $_kintSettings );

--- a/inc/kintParser.class.php
+++ b/inc/kintParser.class.php
@@ -80,6 +80,14 @@ abstract class kintParser extends kintVariableData
 
 		# objects can be presented in a different way altogether, INSTEAD, not ALONGSIDE the generic parser
 		if ( $varType === 'object' ) {
+			// exclude certain classes as per config
+			foreach(Kint::$excludeClassInstances as $className) {
+				if ($variable instanceof $className) {
+					$varData->value = 'EXCLUDED';
+					return $varData;
+				}
+			}
+
 			foreach ( self::$_objectParsers as $parserClass ) {
 				$className = 'Kint_Objects_' . $parserClass;
 


### PR DESCRIPTION
Can probably do with some snagging - but does the job at least for me.

Example use with Symfony2:
$_kintSettings['excludeClassInstances'] = ['\Symfony\Component\DependencyInjection\Container'];

and then the DIC doesn't get dumped which speeds things up drastically.
