### PR TITLE
Add ability to exclude certain class instances from being dumped

### DIFF
--- a/Kint.class.php
+++ b/Kint.class.php
@@ -48,6 +48,7 @@ class Kint
 	public static $maxLevels;
 	public static $theme;
 	public static $expandedByDefault;
+    public static $excludeClassInstances;
 
 	public static $cliDetection;
 	public static $cliColors;

--- a/config.default.php
+++ b/config.default.php
@@ -90,5 +90,7 @@ $_kintSettings['cliDetection'] = true;
  */
 $_kintSettings['cliColors'] = true;
 
+/** @var array - allows to exclude certain classes from being parsed, must be a list of fully qualified domain names */
+$_kintSettings['excludeClassInstances'] = [];
 
 unset( $_kintSettings );

--- a/parsers/objects/excluded.php
+++ b/parsers/objects/excluded.php
@@ -1,0 +1,18 @@
+<?php
+
+class Kint_Objects_Excluded extends KintObject
+{
+    public function parse( & $variable )
+    {
+        // exclude certain classes as per config
+        foreach(Kint::$excludeClassInstances as $className) {
+            if ($variable instanceof $className) {
+                $this->name = $className;
+                $this->value = 'Excluded by configuration';
+                return array();
+            }
+        }
+        return false;
+    }
+}
+


### PR DESCRIPTION
As per:
https://github.com/raveren/kint/issues/185

Example use with Symfony2:
$_kintSettings['excludeClassInstances'] = ['\Symfony\Component\DependencyInjection\Container'];

and then the DIC doesn't get dumped which helps a lot.
