### PR TITLE
Get mini trace if called through eval

### DIFF
--- a/Kint.class.php
+++ b/Kint.class.php
@@ -401,7 +401,8 @@ class Kint
 		}
 		$callee = $step;
 
-		if ( !isset( $callee['file'] ) || !is_readable( $callee['file'] ) ) return false;
+		if ( !isset( $callee['file'] ) || !is_readable( $callee['file'] ) )
+			return array( null, null, null, null, $miniTrace );
 
 
 		# open the file and read it up to the position where the function call expression ended


### PR DESCRIPTION
Currently I'm setting the file and line of the `$callee` to the `call_user_func` call, but simply returning an array of empty values with the mini trace at the end is also a possibility
