### PR TITLE
Bugfix: Check aliases case sensitive

### DIFF
--- a/Kint.class.php
+++ b/Kint.class.php
@@ -603,14 +603,18 @@ class Kint
 	{
 		if ( isset( $step['class'] ) ) {
 			foreach ( self::$aliases['methods'] as $alias ) {
-				if ( $alias[0] === strtolower( $step['class'] ) && $alias[1] === strtolower( $step['function'] ) ) {
+				if ( strtolower( $alias[0] ) === strtolower( $step['class'] ) && strtolower( $alias[1] ) === strtolower( $step['function'] ) ) {
 					return true;
 				}
 			}
-			return false;
 		} else {
-			return in_array( strtolower( $step['function'] ), self::$aliases['functions'], true );
+			foreach ( self::$aliases['functions'] as $alias ) {
+				if ( strtolower( $alias ) === strtolower( $step['function'] ) ) {
+					return true;
+				}
+			}
 		}
+                return false;
 	}
 
 	private static function _parseTrace( array $data )


### PR DESCRIPTION
The aliases property can help kint wrappers keep clean output, but currently it's case insensitive. (Did you find a quirk in a specific version of PHP's debug_backtrace?)

This means it will incorrectly identify `test` `Test` `TEST` and `tEsT` (Among others) as being an internal function call, breaking modifiers, the minitrace, and full traces.
