### PR TITLE
Return provided data

### DIFF
--- a/Kint.class.php
+++ b/Kint.class.php
@@ -220,7 +220,7 @@ class Kint
 		if ( $trace ) {
 			$output .= call_user_func( array( $decorator, 'decorateTrace' ), $trace );
 		} else {
-      $dataArray = func_num_args() === 0
+			$dataArray = func_num_args() === 0
 				? array( "[[no arguments passed]]" )
 				: func_get_args();
 

--- a/Kint.class.php
+++ b/Kint.class.php
@@ -220,11 +220,11 @@ class Kint
 		if ( $trace ) {
 			$output .= call_user_func( array( $decorator, 'decorateTrace' ), $trace );
 		} else {
-			$data = func_num_args() === 0
+      $dataArray = func_num_args() === 0
 				? array( "[[no arguments passed]]" )
 				: func_get_args();
 
-			foreach ( $data as $k => $argument ) {
+			foreach ( $dataArray as $k => $argument ) {
 				kintParser::reset();
 				# when the dump arguments take long to generate output, user might have changed the file and
 				# Kint might not parse the arguments correctly, so check if names are set and while the
@@ -261,7 +261,7 @@ class Kint
 		if ( self::$returnOutput ) return $output;
 
 		echo $output;
-		return '';
+		return $data;
 	}
 
 


### PR DESCRIPTION
Hello @reveren  :)

I am Sebastian, author (in 2010) of a very similar tool (but very modest in comparison):

[http://inspect.ip1.cc](http://inspect.ip1.cc)  (It's in spanish but you can see it's basically the same)

I would really love to ditch my old "inspect" class and start using your fantastic Kint!

But there's a feature in my tool that Kint is missing, and I think it would be a nice improvement.

By default Kint returns an empty string.  To me, returning the same value received as first parameter makes a lot more sense.  That would allow us to inspect mid-expression values:

if ( !is_readable( $cssFile = $baseDir . **d(** _Kint::$theme_ **)** . '.css' ) ) {

Modifiers will still replace the returned value as intended.

What do you think?