### PR TITLE
define KINT_DIR if not defined before, change to can load another init_helpers.php

### DIFF
--- a/init.php
+++ b/init.php
@@ -4,10 +4,6 @@
  *
  * https://github.com/kint-php/kint
  */
-if (defined('KINT_DIR')) {
-    return;
-}
-
 require_once dirname(__FILE__).'/init_header.php';
 
 // Check composer for extras disabling default helper functions

--- a/init_header.php
+++ b/init_header.php
@@ -21,15 +21,14 @@
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-if (defined('KINT_DIR')) {
-    return;
+if (!defined('KINT_DIR')) {
+    define('KINT_DIR', dirname(__FILE__));
 }
 
 if (version_compare(PHP_VERSION, '5.1.2') < 0) {
     throw new Exception('Kint 2.0 requires PHP 5.1.2 or higher');
 }
 
-define('KINT_DIR', dirname(__FILE__));
 define('KINT_WIN', DIRECTORY_SEPARATOR !== '/');
 define('KINT_PHP52', (version_compare(PHP_VERSION, '5.2') >= 0));
 define('KINT_PHP522', (version_compare(PHP_VERSION, '5.2.2') >= 0));


### PR DESCRIPTION
hi
simple and little changes related to [issue 256](https://github.com/kint-php/kint/issues/256) 

now we can define KINT_DIR before require composer autoload and make it compatible with us use like overwrite laravel dd to show use power of Kint.