### PR TITLE
Add smarty plugin

### DIFF
--- a/src/Kint.php
+++ b/src/Kint.php
@@ -154,7 +154,6 @@ class Kint
         'Kint\\Parser\\JsonPlugin',
         'Kint\\Parser\\MicrotimePlugin',
         'Kint\\Parser\\SimpleXMLElementPlugin',
-        'Kint\\Parser\\SmartyPlugin',
         'Kint\\Parser\\SplFileInfoPlugin',
         'Kint\\Parser\\SplObjectStoragePlugin',
         'Kint\\Parser\\StreamPlugin',

--- a/src/Kint.php
+++ b/src/Kint.php
@@ -154,6 +154,7 @@ class Kint
         'Kint\\Parser\\JsonPlugin',
         'Kint\\Parser\\MicrotimePlugin',
         'Kint\\Parser\\SimpleXMLElementPlugin',
+        'Kint\\Parser\\SmartyPlugin',
         'Kint\\Parser\\SplFileInfoPlugin',
         'Kint\\Parser\\SplObjectStoragePlugin',
         'Kint\\Parser\\StreamPlugin',

--- a/src/Parser/SmartyPlugin.php
+++ b/src/Parser/SmartyPlugin.php
@@ -1,5 +1,30 @@
 <?php
 
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2013 Jonathan Vollebregt (jnvsor@gmail.com), Rokas Šleinius (raveren@gmail.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+namespace Kint\Parser;
+
 use Kint\Object\BasicObject;
 use Kint\Object\Representation\Representation;
 use Kint\Parser\Parser;
@@ -32,7 +57,7 @@ class kint_smarty extends Plugin
 		if ($className === 'Smarty_Variable') {
 			$o = $this->parser->parse($var->value, $o); // simply replace with its value
 			$o->type = 'Smarty Variable :: '.$o->type;
-			
+
 			$this->parser->haltParse();
 			return;
 		}
@@ -67,7 +92,7 @@ class kint_smarty extends Plugin
 		);
 		$o->addRepresentation($r);
 
-		$o->classname = $className; // todo this is necessary for TraceFrameObject.php:95 to not throw an error 
+		$o->classname = $className; // TODO this is necessary for TraceFrameObject.php:95 to not throw an error 
 		$o->type = $className;
 
 

--- a/src/Parser/SmartyPlugin.php
+++ b/src/Parser/SmartyPlugin.php
@@ -27,75 +27,73 @@ namespace Kint\Parser;
 
 use Kint\Object\BasicObject;
 use Kint\Object\Representation\Representation;
-use Kint\Parser\Parser;
-use Kint\Parser\Plugin;
 
 class kint_smarty extends Plugin
 {
-	public function getTypes()
-	{
-		return ['object'];
-	}
+    public function getTypes()
+    {
+        return ['object'];
+    }
 
-	public function getTriggers()
-	{
-		return Parser::TRIGGER_BEGIN;
-	}
+    public function getTriggers()
+    {
+        return Parser::TRIGGER_BEGIN;
+    }
 
-	public function parse(&$var, BasicObject &$o, $trigger)
-	{
-		$className = \get_class($var);
-		$supportedClasses = [
-			'Smarty_Internal_Template',
-			'Smarty_Variable',
-			'Smarty',
-		];
-		if (!\in_array($className, $supportedClasses)) {
-			return;
-		}
+    public function parse(&$var, BasicObject &$o, $trigger)
+    {
+        $className = \get_class($var);
+        $supportedClasses = [
+            'Smarty_Internal_Template',
+            'Smarty_Variable',
+            'Smarty',
+        ];
+        if (!\in_array($className, $supportedClasses)) {
+            return;
+        }
 
-		if ($className === 'Smarty_Variable') {
-			$o = $this->parser->parse($var->value, $o); // simply replace with its value
-			$o->type = 'Smarty Variable :: '.$o->type;
+        if ($className === 'Smarty_Variable') {
+            $o = $this->parser->parse($var->value, $o); // simply replace with its value
+            $o->type = 'Smarty Variable :: ' . $o->type;
 
-			$this->parser->haltParse();
-			return;
-		}
+            $this->parser->haltParse();
+            return;
+        }
 
-		$r = new Representation('Assigned variables');
-		foreach ($var->tpl_vars as $name => $val) {
-			$r->contents[] = $this->parser->parse(
-				$val->value,
-				BasicObject::blank($name)
-			);
-		}
-		$o->addRepresentation($r);
+        $r = new Representation('Assigned variables');
+        foreach ($var->tpl_vars as $name => $val) {
+            $r->contents[] = $this->parser->parse(
+                $val->value,
+                BasicObject::blank($name)
+            );
+        }
+        $o->addRepresentation($r);
 
-		$r = new Representation('Globally assigned variables');
-		foreach (Smarty::$global_tpl_vars as $name => $val) {
-			if ($name === 'SCRIPT_NAME') {
-				continue;
-			}
+        $r = new Representation('Globally assigned variables');
+        foreach (\Smarty::$global_tpl_vars as $name => $val) {
+            if ($name === 'SCRIPT_NAME') {
+                continue;
+            }
 
-			$r->contents[] = $this->parser->parse(
-				$val->value,
-				BasicObject::blank($name)
-			);
-		}
-		$o->addRepresentation($r);
+            $r->contents[] = $this->parser->parse(
+                $val->value,
+                BasicObject::blank($name)
+            );
+        }
+        $o->addRepresentation($r);
 
-		$r = new Representation('Configuration');
-		$var1 = $var->getCompileDir();
-		$r->contents[] = $this->parser->parse(
-			$var1,
-			BasicObject::blank('Compiled files stored in')
-		);
-		$o->addRepresentation($r);
+        $r = new Representation('Configuration');
+        $var1 = $var->getCompileDir();
+        $r->contents[] = $this->parser->parse(
+            $var1,
+            BasicObject::blank('Compiled files stored in')
+        );
+        $o->addRepresentation($r);
 
-		$o->classname = $className; // TODO this is necessary for TraceFrameObject.php:95 to not throw an error 
-		$o->type = $className;
+        $o->classname = $className; // TODO this is necessary for TraceFrameObject.php:95 to not throw an error 
+        $o->type = $className;
 
 
-		$this->parser->haltParse();
-	}
+        $this->parser->haltParse();
+    }
 }

--- a/src/Parser/SmartyPlugin.php
+++ b/src/Parser/SmartyPlugin.php
@@ -1,0 +1,76 @@
+<?php
+
+use Kint\Object\BasicObject;
+use Kint\Object\Representation\Representation;
+use Kint\Parser\Parser;
+use Kint\Parser\Plugin;
+
+class kint_smarty extends Plugin
+{
+	public function getTypes()
+	{
+		return ['object'];
+	}
+
+	public function getTriggers()
+	{
+		return Parser::TRIGGER_BEGIN;
+	}
+
+	public function parse(&$var, BasicObject &$o, $trigger)
+	{
+		$className = \get_class($var);
+		$supportedClasses = [
+			'Smarty_Internal_Template',
+			'Smarty_Variable',
+			'Smarty',
+		];
+		if (!\in_array($className, $supportedClasses)) {
+			return;
+		}
+
+		if ($className === 'Smarty_Variable') {
+			$o = $this->parser->parse($var->value, $o); // simply replace with its value
+			$o->type = 'Smarty Variable :: '.$o->type;
+			
+			$this->parser->haltParse();
+			return;
+		}
+
+		$r = new Representation('Assigned variables');
+		foreach ($var->tpl_vars as $name => $val) {
+			$r->contents[] = $this->parser->parse(
+				$val->value,
+				BasicObject::blank($name)
+			);
+		}
+		$o->addRepresentation($r);
+
+		$r = new Representation('Globally assigned variables');
+		foreach (Smarty::$global_tpl_vars as $name => $val) {
+			if ($name === 'SCRIPT_NAME') {
+				continue;
+			}
+
+			$r->contents[] = $this->parser->parse(
+				$val->value,
+				BasicObject::blank($name)
+			);
+		}
+		$o->addRepresentation($r);
+
+		$r = new Representation('Configuration');
+		$var1 = $var->getCompileDir();
+		$r->contents[] = $this->parser->parse(
+			$var1,
+			BasicObject::blank('Compiled files stored in')
+		);
+		$o->addRepresentation($r);
+
+		$o->classname = $className; // todo this is necessary for TraceFrameObject.php:95 to not throw an error 
+		$o->type = $className;
+
+
+		$this->parser->haltParse();
+	}
+}

--- a/src/Parser/SmartyPlugin.php
+++ b/src/Parser/SmartyPlugin.php
@@ -62,6 +62,10 @@ class SmartyPlugin extends Plugin
 
         $r = new Representation('Assigned variables');
         foreach ($var->tpl_vars as $name => $val) {
+            if ($name === 'SCRIPT_NAME') {
+                continue;
+            }
+
             $r->contents[] = $this->parser->parse(
                 $val->value,
                 BasicObject::blank($name)

--- a/src/Parser/SmartyPlugin.php
+++ b/src/Parser/SmartyPlugin.php
@@ -28,7 +28,7 @@ namespace Kint\Parser;
 use Kint\Object\BasicObject;
 use Kint\Object\Representation\Representation;
 
-class kint_smarty extends Plugin
+class SmartyPlugin extends Plugin
 {
     public function getTypes()
     {

--- a/src/Parser/SmartyPlugin.php
+++ b/src/Parser/SmartyPlugin.php
@@ -92,7 +92,15 @@ class SmartyPlugin extends Plugin
             $var1,
             BasicObject::blank('Compiled files stored in')
         );
-        $o->addRepresentation($r);
+        
+        if (!empty($var->registered_plugins)) {
+            $var1 = $var->registered_plugins;
+            $r->contents[] = $this->parser->parse(
+                $var1,
+                BasicObject::blank('User registered plugins')
+            );
+            $o->addRepresentation($r);
+        }
 
         $o->classname = $className; // TODO this is necessary for TraceFrameObject.php:95 to not throw an error 
         $o->type = $className;


### PR DESCRIPTION
Hey, I ran into a foreseen bug #70 while debugging an old system.

[Smarty](https://www.smarty.net/) would kill Kint not only by it's share size of objects, but also since calling its `__toString` would cause exceptions. So I decided to have some fun and wrote a plugin to hit two birds! :)

The process was mostly painless, the way you handled the plugin architecture is not just workable, I'd say it's extremely elegant for what it is!

I did have some counter-intuitive problems to solve - precisely how to display a sub-element of a variable instead of the variable itself; this ended up working
```php
$o = $this->parser->parse($var->value, $o);
```
maybe I should add this as a tip to [the docs](https://kint-php.github.io/kint/writing-plugins/)? 

Also, as I mentioned in the PR code, I stumbled on a bug which I'm too afraid to debug:

Trace callee object display throws [error here](https://github.com/kint-php/kint/blob/add-smarty-plugin/src/Object/TraceFrameObject.php#L95) if I do `parser->haltParse()` without hardcoding a `classname` member onto `BasicObject &$o` [manually](https://github.com/kint-php/kint/compare/add-smarty-plugin?expand=1#diff-68cf966c5e12593677ac4a4972935bddR93). If I don't `haltParse` - no error, but all Smarty dirt is visible again :)

I hope I'm explaining myself clearly, it's 3:30 in the morning here :) I also hope merging a pull request allows you to squash my commits into one.

Anyway, looking forward to hearing for you, and once again - great job :)