### PR TITLE
Made the kint display wrapper at the bottom opt-in

### DIFF
--- a/src/Renderer/RichRenderer.php
+++ b/src/Renderer/RichRenderer.php
@@ -118,7 +118,7 @@ class RichRenderer extends Renderer
      *
      * @var bool
      */
-    public static $folder = true;
+    public static $folder = false;
 
     /**
      * Sort mode for object properties.


### PR DESCRIPTION
To turn it back on again use
`\Kint\Renderer\RichRenderer::$folder = true;`

this change should maybe be reflected in documentation..?