### PR TITLE
Recursion detection by reference 

### DIFF
--- a/src/Parser/Parser.php
+++ b/src/Parser/Parser.php
@@ -77,7 +77,7 @@ class Parser
             $this->depth_limit = $depth_limit;
         }
 
-	$this->recursion = new Recursion;
+        $this->recursion = new Recursion;
     }
 
     /**
@@ -154,9 +154,9 @@ class Parser
 
         switch ($o->type) {
             case 'array':
-	        if (0 === $o->depth) {
+                if (0 === $o->depth) {
 	            $this->recursion->cleanArrays();
-	        }
+                }
                 return $this->parseArray($var, $o);
             case 'boolean':
             case 'double':
@@ -164,9 +164,9 @@ class Parser
             case 'null':
                 return $this->parseGeneric($var, $o);
             case 'object':
-	        if (0 === $o->depth) {
+                if (0 === $o->depth) {
 	            $this->recursion->cleanObjects();
-	        }
+                }
                 return $this->parseObject($var, $o);
             case 'resource':
                 return $this->parseResource($var, $o);
@@ -323,8 +323,8 @@ class Parser
         $array->transplant($o);
         $array->size = \count($var);
 
-	// this is a "known array", which has already been
-	// introduced before, and that constitutes recursion
+        // this is a "known array", which has already been
+        // introduced before, and that constitutes recursion
         if ($this->recursion->isArrayRecursion($var)) {
             $array->hints[] = 'recursion';
 
@@ -415,8 +415,8 @@ class Parser
         $object->spl_object_hash = $hash;
         $object->size = \count($values);
 
-	// this is a "known object", which has already been
-	// introduced before, and that constitutes recursion
+        // this is a "known object", which has already been
+        // introduced before, and that constitutes recursion
         if ($this->recursion->isObjectRecursion($var)) {
             $object->hints[] = 'recursion';
 

--- a/src/Parser/Parser.php
+++ b/src/Parser/Parser.php
@@ -323,9 +323,9 @@ class Parser
         $array->transplant($o);
         $array->size = \count($var);
 
-        // this is a "known array", which has already been
+        // this is a "known array reference", which has already been
         // introduced before, and that constitutes recursion
-        if ($this->recursion->isArrayRecursion($var)) {
+        if (!empty($array->reference) && $this->recursion->isArrayRecursion($var)) {
             $array->hints[] = 'recursion';
 
             $this->applyPlugins($var, $array, self::TRIGGER_RECURSION);

--- a/src/Parser/Recursion.php
+++ b/src/Parser/Recursion.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Kint\Parser;
+
+/**
+ * Recursion tracker
+ *
+ * Collects references to arrays and objects introduced during the
+ * inspection of a variable inside the {@link Kint\Parser\Parser}.
+ * Any variables introduced more than once constitutes recursion.
+ *
+ * @author Kaloyan KT Tsvetkov <kaloyan@gmail.com>
+ */
+final class Recursion
+{
+    /**
+     * @var array list of referenced arrays
+     * @see Recursion::isArrayRecursion();
+     */
+    protected $knownArrays = [];
+
+    /**
+     * Checks for array recursion
+     *
+     * @param array &$var
+     * @return bool
+     */
+    function isArrayRecursion(array &$var) : bool
+    {
+        foreach ($this->knownArrays as &$known)
+        {
+            if ($known === $var)
+            {
+                return true;
+            }
+        }
+
+        $this->knownArrays[] =& $var;
+        return false;
+    }
+
+    /**
+     * Cleans the collected array references
+     */
+    function cleanArrays()
+    {
+        $this->knownArrays = [];
+    }
+
+    /**
+     * @var array list of referenced objects
+     * @see Recursion::isObjectRecursion();
+     */
+    protected $knownObjects = [];
+
+    /**
+     * Checks for object recursion
+     *
+     * @param object &$var
+     * @return bool
+     */
+    function isObjectRecursion(&$var) : bool
+    {
+        // can not type-hint generic object values,
+	// so the best option is to use is_object()
+        if (!is_object($var))
+        {
+            return false;
+        }
+
+	// we can foreach the list of $knownObjects
+	// as we do with the arrays, but using the
+	// spl_object_hash() is faster
+        $hash = \spl_object_hash($var);
+        if (!empty($this->knownObjects[ $hash ]))
+        {
+            return true;
+        }
+
+        $this->knownObjects[ $hash ] =& $var;
+        return false;
+    }
+
+    /**
+     * Cleans the collected object references
+     */
+    function cleanObjects()
+    {
+        $this->knownObjects = [];
+    }
+}

--- a/src/Parser/Recursion.php
+++ b/src/Parser/Recursion.php
@@ -55,7 +55,9 @@ final class Recursion
                 $var[ $this->marker ] = 1;
                 $recursion = !empty($known[ $this->marker ]);
                 unset($var[ $this->marker ]);
-                return $recursion;
+                if ($recursion) {
+                    return true;
+                }
             }
         }
 

--- a/src/Parser/Recursion.php
+++ b/src/Parser/Recursion.php
@@ -62,15 +62,15 @@ final class Recursion
     function isObjectRecursion(&$var) : bool
     {
         // can not type-hint generic object values,
-	// so the best option is to use is_object()
+        // so the best option is to use is_object()
         if (!is_object($var))
         {
             return false;
         }
 
-	// we can foreach the list of $knownObjects
-	// as we do with the arrays, but using the
-	// spl_object_hash() is faster
+        // we can foreach the list of $knownObjects
+        // as we do with the arrays, but using the
+        // spl_object_hash() is faster
         $hash = \spl_object_hash($var);
         if (!empty($this->knownObjects[ $hash ]))
         {

--- a/src/Parser/Recursion.php
+++ b/src/Parser/Recursion.php
@@ -46,33 +46,27 @@ final class Recursion
      */
     function isArrayRecursion(array &$var) : bool
     {
-        foreach ($this->knownArrays as &$known)
+        $count = count($var);
+        if (!empty($this->knownArrays[$count]))
         {
-            if ($known === $var)
+            $var[ $this->marker ] = 1;
+            $recursion = false;
+            foreach ($this->knownArrays[$count] as &$known)
             {
-                // test if they are copies of one another,
-                // or they are reference to the same array
-                $var[ $this->marker ] = 1;
-                $recursion = !empty($known[ $this->marker ]);
-                unset($var[ $this->marker ]);
-                if ($recursion) {
-                    return true;
+                if ($recursion = !empty($known[ $this->marker ]))
+                {
+                    break;
                 }
             }
-        }
 
-        // we are only interested in arrays with
-        // nested other arrays and objects inside,
-        // where the recursion can occur
-        foreach ($var as $k => &$v)
-        {
-            if (is_object($v) || is_array($v))
+            unset($var[ $this->marker ]);
+            if ($recursion)
             {
-                $this->knownArrays[] =& $var;
-                break;
+                return true;
             }
         }
 
+        $this->knownArrays[$count][] =& $var;
         return false;
     }
 
@@ -105,9 +99,6 @@ final class Recursion
             return false;
         }
 
-        // we can foreach the list of $knownObjects
-        // as we do with the arrays, but using the
-        // spl_object_hash() is faster
         $hash = spl_object_hash($var);
         if (!empty($this->knownObjects[ $hash ]))
         {

--- a/src/Parser/TablePlugin.php
+++ b/src/Parser/TablePlugin.php
@@ -46,7 +46,7 @@ class TablePlugin extends Plugin
             return;
         }
 
-        $array = $this->parser->getCleanArray($var);
+        $array = $var;
 
         if (\count($array) < 2) {
             return;

--- a/src/Parser/TracePlugin.php
+++ b/src/Parser/TracePlugin.php
@@ -50,7 +50,7 @@ class TracePlugin extends Plugin
             return;
         }
 
-        $trace = $this->parser->getCleanArray($var);
+        $trace = $var;
 
         if (\count($trace) !== \count($o->value->contents) || !Utils::isTrace($trace)) {
             return;

--- a/tests/Parser/ParserTest.php
+++ b/tests/Parser/ParserTest.php
@@ -56,10 +56,6 @@ class ParserTest extends TestCase
      */
     public function testConstruct()
     {
-        $marker = new ReflectionProperty('Kint\\Parser\\Parser', 'marker');
-
-        $marker->setAccessible(true);
-
         $p1 = new Parser();
 
         $this->assertFalse($p1->getDepthLimit());
@@ -69,7 +65,6 @@ class ParserTest extends TestCase
 
         $this->assertSame(123, $p2->getDepthLimit());
         $this->assertSame('asdf', $p2->getCallerClass());
-        $this->assertNotSame($marker->getValue($p1), $marker->getValue($p2));
     }
 
     /**

--- a/tests/Parser/ParserTest.php
+++ b/tests/Parser/ParserTest.php
@@ -941,41 +941,4 @@ class ParserTest extends TestCase
     {
         $this->assertSame($expected, $parser->childHasPath($parent, $child));
     }
-
-    /**
-     * @covers \Kint\Parser\Parser::getCleanArray
-     */
-    public function testGetCleanArray()
-    {
-        $p = new Parser();
-        $b = Value::blank();
-        $v = [1234];
-
-        $arrays = [];
-
-        $pl = new ProxyPlugin(
-            ['array'],
-            Parser::TRIGGER_SUCCESS,
-            function (&$var, &$o, $trig, $parser) use (&$arrays) {
-                $clean = $parser->getCleanArray($var);
-
-                // This here is exactly why you should never alter input
-                // variables in plugins and always use getCleanArray
-                $var[] = 4321;
-                $clean[] = 8765;
-
-                $arrays = [
-                    'var' => $var,
-                    'clean' => $clean,
-                ];
-            }
-        );
-        $p->addPlugin($pl);
-
-        $p->parse($v, clone $b);
-
-        $this->assertSame([1234, 4321], $v);
-        $this->assertSame([1234, 8765], $arrays['clean']);
-        $this->assertSame(\count($v) + 1, \count($arrays['var']));
-    }
 }


### PR DESCRIPTION
As discussed in https://github.com/kint-php/kint/issues/203 this is recursion tracking by reference. The array and object references are collected in a "register" and if they are encountered a second time, that is considered a recursion.

One of the benefits of this approach is that arrays are never tainted with markers, and at any time a plugin can pick the parsed array variable as it is.

I do use hashes to address the object references, but that's because it is faster that way instead of traversing the whole list of knownObjects.

@jnvsor has some concerns about memory leaks and performance, and I'll be looking forward for ways how to test these cases. So far I've only done the examples from https://github.com/kint-php/kint/issues/203 and the `ParserTest.php` unit test, and both work OK.

Structurally, the output of the recursions is the same as from `var_dump()`. Here's what I used to compare:
```php 
<?php

include 'vendor/autoload.php';

$a = ["Array 1"];
$b = ["Array 2"];
$a[] = &$b;
$b[] = &$a;

!d($a);
!d($b);

var_dump($a);
var_dump($b);

$r = (object) ['a' => 23, 'b' => 45];
$r->c =& $r;
!d($r);

var_dump($r);
```
There is a screenshot of the output [here](https://github.com/kint-php/kint/issues/203#issuecomment-673141991) 