### PR TITLE
Fix #374

### DIFF
--- a/src/Renderer/RichRenderer.php
+++ b/src/Renderer/RichRenderer.php
@@ -326,7 +326,7 @@ class RichRenderer extends Renderer
 
         foreach ($o->getRepresentations() as $rep) {
             $result = $this->renderTab($o, $rep);
-            if (\strlen($result)) {
+            if (isset($result) && \strlen($result)) {
                 $contents[] = $result;
                 $tabs[] = $rep;
             }


### PR DESCRIPTION
strlen(): Passing null to parameter #1 ($string) of type string is deprecated on PHP 8.1