### PR TITLE
Composer 2.0 Compatibility

### DIFF
--- a/src/Utils.php
+++ b/src/Utils.php
@@ -118,7 +118,9 @@ final class Utils
                     continue;
                 }
 
-                foreach ($packages as $package) {
+                // Composer 2.0 Compatibility: packages are now wrapped into a "packages" top level key instead of the whole file being the package array
+                // @see https://getcomposer.org/upgrade/UPGRADE-2.0.md
+                foreach ($packages['packages'] ?? $packages as $package) {
                     if (isset($package['extra'][$key]) && \is_array($package['extra'][$key])) {
                         $extras = \array_replace($extras, $package['extra'][$key]);
                     }


### PR DESCRIPTION
Composer 2.0 Compatibility: 
* packages are now wrapped into a "packages" top level key instead of the whole file being the package array

Documentation: https://getcomposer.org/upgrade/UPGRADE-2.0.md