### PR TITLE
Add 'dev' keyword to composer.json to trigger `--dev` prompt

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "kint-php/kint",
     "description": "Kint - debugging tool for PHP developers",
-    "keywords": ["kint", "php", "debug"],
+    "keywords": ["kint", "php", "debug", "dev"],
     "type": "library",
     "homepage": "https://kint-php.github.io/kint/",
     "license": "MIT",


### PR DESCRIPTION
Composer 2.4 and later can automatically suggest to use the `--dev` flag when someone runs `composer require kint-php/kint` without the `--dev` flag.

See [Get Composer to suggest dev packages to `require-dev`](https://php.watch/articles/composer-prompt-require-dev-dev-packages)