### PR TITLE
chore: allow unsupported php version & parallel config in `PHP-CS-Fixer`

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -25,8 +25,12 @@ declare(strict_types=1);
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+use PhpCsFixer\Runner\Parallel\ParallelConfigFactory;
+
 return (new PhpCsFixer\Config())
     ->setRiskyAllowed(true)
+    ->setParallelConfig(ParallelConfigFactory::detect())
+    ->setUnsupportedPhpVersionAllowed(true)
     ->setRules([
         '@Symfony' => true,
         'array_indentation' => true,

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "php": ">=7.4"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^3",
+        "friendsofphp/php-cs-fixer": "^3.86.0",
         "phpunit/phpunit": "^9",
         "symfony/finder": ">=7",
         "seld/phar-utils": "^1",


### PR DESCRIPTION
- Bump `friendsofphp/php-cs-fixer` to minimum `^3.86.0`
- `PHP_CS_FIXER_IGNORE_ENV` already deprecated and change to new config
- Set parallel config for faster fix